### PR TITLE
`stripAnnotations` option, and extra fixes and stuff

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,10 +70,6 @@ dependencies {
     testImplementation(kotlin("test"))
 }
 
-tasks.test {
-    useJUnitPlatform()
-}
-
 tasks.jar {
     from(shared.output)
 
@@ -124,6 +120,11 @@ val agentShadeJar = tasks.register<ShadowJar>("agentShadowJar") {
             "Can-Redefine-Classes" to "true",
         )
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
+    dependsOn(tasks.jar, annotationJar, agentShadeJar)
 }
 
 tasks.assemble {

--- a/expect-platform-test/build.gradle.kts
+++ b/expect-platform-test/build.gradle.kts
@@ -4,6 +4,12 @@ import xyz.wagyourtail.unimined.expect.task.ExpectPlatformJar
 import xyz.wagyourtail.unimined.expect.ExpectPlatformExtension
 import java.util.*
 
+val epVersion: String = run {
+    Properties().apply {
+        load(file("../gradle.properties").reader())
+    }.getProperty("version", "1.1.0")
+}
+
 buildscript {
     repositories {
         mavenCentral()
@@ -12,9 +18,8 @@ buildscript {
         }
     }
     dependencies {
-
         if (!project.hasProperty("runningTest")) {
-            classpath("xyz.wagyourtail.unimined.expect-platform:expect-platform:1.0.3")
+            classpath("xyz.wagyourtail.unimined.expect-platform:expect-platform:$epVersion")
             classpath("org.ow2.asm:asm:9.7")
             classpath("org.ow2.asm:asm-commons:9.7")
             classpath("org.ow2.asm:asm-tree:9.7")
@@ -34,7 +39,6 @@ plugins {
 
 
 apply(plugin = "xyz.wagyourtail.unimined.expect-platform")
-
 
 sourceSets {
     create("a") {

--- a/expect-platform-test/build.gradle.kts
+++ b/expect-platform-test/build.gradle.kts
@@ -2,9 +2,10 @@
 import xyz.wagyourtail.unimined.expect.task.ExpectPlatformFiles
 import xyz.wagyourtail.unimined.expect.task.ExpectPlatformJar
 import xyz.wagyourtail.unimined.expect.expectPlatform
-import java.util.Properties
 
-val epVersion: String = file("../gradle.properties").let { Properties().apply { load(it.reader()) } }.getProperty("version")
+val epVersion = projectDir.parentFile.resolve("gradle.properties").readText()
+    .split("\n").find { it.startsWith("version") }!!
+    .split("=").last().trimStart()
 
 buildscript {
     repositories {
@@ -15,7 +16,10 @@ buildscript {
     }
     dependencies {
         if (!project.hasProperty("runningTest")) {
-            classpath("xyz.wagyourtail.unimined.expect-platform:expect-platform:1.1.0")
+            val epVersion = projectDir.parentFile.resolve("gradle.properties").readText()
+                .split("\n").find { it.startsWith("version") }!!
+                .split("=").last().trimStart()
+            classpath("xyz.wagyourtail.unimined.expect-platform:expect-platform:${epVersion}")
             classpath("org.ow2.asm:asm:9.7")
             classpath("org.ow2.asm:asm-commons:9.7")
             classpath("org.ow2.asm:asm-tree:9.7")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
 
-version = 1.0.5
+version = 1.1.0
 
 asmVersion=9.7

--- a/src/agent/java/xyz/wagyourtail/unimined/expect/ExpectPlatformAgent.java
+++ b/src/agent/java/xyz/wagyourtail/unimined/expect/ExpectPlatformAgent.java
@@ -14,14 +14,20 @@ public class ExpectPlatformAgent {
     private static final String platform = System.getProperty(EXPECT_PLATFORM);
     private static final String remap = System.getProperty(REMAP);
 
-    private static final TransformPlatform transformPlatform = new TransformPlatform(platform, remap);
+    private static final TransformPlatform transformPlatform = new TransformPlatform(platform, remap, false);
 
     public static void premain(String args, Instrumentation inst) {
-        System.out.println("[ExpectPlatformAgent] Platform: " + platform);
-        System.out.println("[ExpectPlatformAgent] Remap: " + transformPlatform.getRemap());
         if (platform == null) {
             throw new IllegalStateException("-D" + EXPECT_PLATFORM + " not set");
         }
+
+        if(!inst.isRetransformClassesSupported()) {
+            System.out.println("[ExpectPlatformAgent] ur instrumentation is bad lol");
+        }
+
+        System.out.println("[ExpectPlatformAgent] Platform: " + platform);
+        System.out.println("[ExpectPlatformAgent] Remap: " + transformPlatform.getRemap());
+
         inst.addTransformer(new ExpectPlatformTransformer(), inst.isRetransformClassesSupported());
     }
 
@@ -33,6 +39,7 @@ public class ExpectPlatformAgent {
 
         @Override
         public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+            System.out.println("[ExpectPlatformAgent] Transforming: " + className);
             ClassReader reader = new ClassReader(classfileBuffer);
             ClassNode classNode = new ClassNode();
             reader.accept(classNode, 0);

--- a/src/annotations/java/xyz/wagyourtail/unimined/expect/Target.java
+++ b/src/annotations/java/xyz/wagyourtail/unimined/expect/Target.java
@@ -8,6 +8,6 @@ public final class Target {
 	 * @return the currently targeted platform
 	 */
 	public static String getCurrentTarget() {
-		throw new AssertionError("failed to transform method");
+		throw new AssertionError("stub method, this shouldn't even be on your runtime classpath!");
 	}
 }

--- a/src/annotations/java/xyz/wagyourtail/unimined/expect/annotation/PlatformOnly.java
+++ b/src/annotations/java/xyz/wagyourtail/unimined/expect/annotation/PlatformOnly.java
@@ -14,6 +14,7 @@ public @interface PlatformOnly {
 	String[] value();
 
 	String FORGE = "forge";
+	String NEOFORGE = "neoforge";
 	String FABRIC = "fabric";
 	String QUIILT = "quilt";
 }

--- a/src/main/kotlin/xyz/wagyourtail/unimined/expect/ExpectPlatformExtension.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/expect/ExpectPlatformExtension.kt
@@ -11,6 +11,9 @@ import xyz.wagyourtail.unimined.expect.transform.ExpectPlatformParams
 import xyz.wagyourtail.unimined.expect.transform.ExpectPlatformTransform
 import xyz.wagyourtail.unimined.expect.utils.FinalizeOnRead
 
+val Project.expectPlatform: ExpectPlatformExtension
+    get() = extensions.getByType(ExpectPlatformExtension::class.java)
+
 abstract class ExpectPlatformExtension(val project: Project) {
 
     @set:VisibleForTesting

--- a/src/main/kotlin/xyz/wagyourtail/unimined/expect/ExpectPlatformExtension.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/expect/ExpectPlatformExtension.kt
@@ -43,7 +43,7 @@ abstract class ExpectPlatformExtension(val project: Project) {
 
                 spec.parameters {
                     it.platformName.set(platformName)
-                    it.stripAnnotations.set(stripAnnotations)
+                    it.stripAnnotations.convention(stripAnnotations)
                     it.action()
                 }
             }

--- a/src/main/kotlin/xyz/wagyourtail/unimined/expect/ExpectPlatformExtension.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/expect/ExpectPlatformExtension.kt
@@ -9,6 +9,7 @@ import org.gradle.process.JavaExecSpec
 import org.jetbrains.annotations.VisibleForTesting
 import xyz.wagyourtail.unimined.expect.transform.ExpectPlatformParams
 import xyz.wagyourtail.unimined.expect.transform.ExpectPlatformTransform
+import xyz.wagyourtail.unimined.expect.utils.FinalizeOnRead
 
 abstract class ExpectPlatformExtension(val project: Project) {
 
@@ -17,6 +18,8 @@ abstract class ExpectPlatformExtension(val project: Project) {
 
     val annotationsDep by lazy { "xyz.wagyourtail.unimined.expect-platform:expect-platform-annotations:$version" }
     val agentDep by lazy { "xyz.wagyourtail.unimined.expect-platform:expect-platform-agent:$version" }
+
+    val stripAnnotations by FinalizeOnRead(false)
 
     @JvmOverloads
     fun platform(platformName: String, configuration: Configuration, action: ExpectPlatformParams.() -> Unit = {}) {
@@ -40,6 +43,7 @@ abstract class ExpectPlatformExtension(val project: Project) {
 
                 spec.parameters {
                     it.platformName.set(platformName)
+                    it.stripAnnotations.set(stripAnnotations)
                     it.action()
                 }
             }

--- a/src/main/kotlin/xyz/wagyourtail/unimined/expect/task/ExpectPlatformFiles.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/expect/task/ExpectPlatformFiles.kt
@@ -52,7 +52,6 @@ abstract class ExpectPlatformFiles : ConventionTask(), ExpectPlatformParams {
         val fileSystems = mutableSetOf<FileSystem>()
 
         try {
-
             outputs.files.forEach { it.deleteRecursively() }
 
             val transformed = toTransform.map { temporaryDir.resolve(it.name) }.map {
@@ -71,7 +70,7 @@ abstract class ExpectPlatformFiles : ConventionTask(), ExpectPlatformParams {
                 }
             }
 
-            val transformer = TransformPlatform(platformName.get(), remap.get(), stripAnnotations.get())
+            val transformer = TransformPlatform(platformName.get(), remap.get(), stripAnnotations.getOrElse(false))
 
             for (i in toTransform.indices) {
                 val input = toTransform[i]

--- a/src/main/kotlin/xyz/wagyourtail/unimined/expect/task/ExpectPlatformFiles.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/expect/task/ExpectPlatformFiles.kt
@@ -7,8 +7,8 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import xyz.wagyourtail.unimined.expect.utils.FinalizeOnRead
 import xyz.wagyourtail.unimined.expect.utils.MustSet
-import xyz.wagyourtail.unimined.expect.ExpectPlatformExtension
 import xyz.wagyourtail.unimined.expect.TransformPlatform
+import xyz.wagyourtail.unimined.expect.expectPlatform
 import xyz.wagyourtail.unimined.expect.transform.ExpectPlatformParams
 import xyz.wagyourtail.unimined.expect.utils.openZipFileSystem
 import java.io.File
@@ -18,11 +18,6 @@ import kotlin.io.path.isDirectory
 import kotlin.io.path.name
 
 abstract class ExpectPlatformFiles : ConventionTask(), ExpectPlatformParams {
-
-    @get:Internal
-    protected val ep by lazy {
-        project.extensions.getByType(ExpectPlatformExtension::class.java)
-    }
 
     @get:InputFiles
     var inputCollection: FileCollection by FinalizeOnRead(MustSet())
@@ -70,7 +65,7 @@ abstract class ExpectPlatformFiles : ConventionTask(), ExpectPlatformParams {
                 }
             }
 
-            val transformer = TransformPlatform(platformName.get(), remap.get(), stripAnnotations.getOrElse(false))
+            val transformer = TransformPlatform(platformName.get(), remap.get(), stripAnnotations.getOrElse(project.expectPlatform.stripAnnotations))
 
             for (i in toTransform.indices) {
                 val input = toTransform[i]

--- a/src/main/kotlin/xyz/wagyourtail/unimined/expect/task/ExpectPlatformFiles.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/expect/task/ExpectPlatformFiles.kt
@@ -46,7 +46,7 @@ abstract class ExpectPlatformFiles : ConventionTask(), ExpectPlatformParams {
     }
 
     @TaskAction
-    fun doTranform() {
+    fun doTransform() {
         var toTransform = inputCollection.map { it.toPath() }.filter { it.exists() }
 
         val fileSystems = mutableSetOf<FileSystem>()
@@ -70,10 +70,13 @@ abstract class ExpectPlatformFiles : ConventionTask(), ExpectPlatformParams {
                     fs.getPath("/")
                 }
             }
+
+            val transformer = TransformPlatform(platformName.get(), remap.get(), stripAnnotations.get())
+
             for (i in toTransform.indices) {
                 val input = toTransform[i]
                 val output = transformed[i]
-                TransformPlatform(platformName.get(), remap.get()).transform(input, output)
+                transformer.transform(input, output)
             }
         } finally {
             fileSystems.forEach { it.close() }

--- a/src/main/kotlin/xyz/wagyourtail/unimined/expect/task/ExpectPlatformJar.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/expect/task/ExpectPlatformJar.kt
@@ -24,7 +24,7 @@ abstract class ExpectPlatformJar : Jar(), ExpectPlatformParams {
 
     @TaskAction
     fun doTransform() {
-        val transformer = TransformPlatform(platformName.get(), remap.get(), stripAnnotations.get())
+        val transformer = TransformPlatform(platformName.get(), remap.get(), stripAnnotations.getOrElse(false))
         for (input in inputFiles) {
             if (input.isDirectory) {
                 val output = temporaryDir.resolve(input.name + "-expect-platform")
@@ -40,7 +40,6 @@ abstract class ExpectPlatformJar : Jar(), ExpectPlatformParams {
                 from(project.zipTree(output))
             } else if (input.exists()) {
                 throw IllegalStateException("ExpectPlatformJar: $input is not a directory or jar file")
-
             }
         }
 

--- a/src/main/kotlin/xyz/wagyourtail/unimined/expect/task/ExpectPlatformJar.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/expect/task/ExpectPlatformJar.kt
@@ -8,23 +8,19 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.bundling.Jar
 import xyz.wagyourtail.unimined.expect.utils.FinalizeOnRead
 import xyz.wagyourtail.unimined.expect.utils.MustSet
-import xyz.wagyourtail.unimined.expect.ExpectPlatformExtension
 import xyz.wagyourtail.unimined.expect.TransformPlatform
+import xyz.wagyourtail.unimined.expect.expectPlatform
 import xyz.wagyourtail.unimined.expect.transform.ExpectPlatformParams
 import xyz.wagyourtail.unimined.expect.utils.openZipFileSystem
 
 abstract class ExpectPlatformJar : Jar(), ExpectPlatformParams {
-
-    private val ep by lazy {
-        project.extensions.getByType(ExpectPlatformExtension::class.java)
-    }
 
     @get:InputFiles
     var inputFiles: FileCollection by FinalizeOnRead(MustSet())
 
     @TaskAction
     fun doTransform() {
-        val transformer = TransformPlatform(platformName.get(), remap.get(), stripAnnotations.getOrElse(false))
+        val transformer = TransformPlatform(platformName.get(), remap.get(), stripAnnotations.getOrElse(project.expectPlatform.stripAnnotations))
         for (input in inputFiles) {
             if (input.isDirectory) {
                 val output = temporaryDir.resolve(input.name + "-expect-platform")

--- a/src/main/kotlin/xyz/wagyourtail/unimined/expect/transform/ExpectPlatformParams.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/expect/transform/ExpectPlatformParams.kt
@@ -19,4 +19,8 @@ interface ExpectPlatformParams : TransformParameters {
     @get:Optional
     val remap: MapProperty<String, String>
 
+    @get:Input
+    @get:Optional
+    val stripAnnotations: Property<Boolean>
+
 }

--- a/src/main/kotlin/xyz/wagyourtail/unimined/expect/transform/ExpectPlatformTransform.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/expect/transform/ExpectPlatformTransform.kt
@@ -16,15 +16,17 @@ abstract class ExpectPlatformTransform : TransformAction<ExpectPlatformParams> {
     override fun transform(outputs: TransformOutputs) {
         val platformName = parameters.platformName.get()
         val remap = parameters.remap.get()
+        val transformer = TransformPlatform(platformName, remap, parameters.stripAnnotations.get())
+
         val input = inputArtifact.get().asFile
         if (input.isDirectory) {
             val output = outputs.dir(input.name + "-expect-platform")
-            TransformPlatform(platformName, remap).transform(input.toPath(), output.toPath())
+            transformer.transform(input.toPath(), output.toPath())
         } else if (input.extension == "jar") {
             val output = outputs.file(input.nameWithoutExtension + "-expect-platform." + input.extension)
             input.toPath().openZipFileSystem().use { inputFs ->
                 output.toPath().openZipFileSystem(mapOf("create" to true)).use { outputFs ->
-                    TransformPlatform(platformName, remap).transform(inputFs.getPath("/"), outputFs.getPath("/"))
+                    transformer.transform(inputFs.getPath("/"), outputFs.getPath("/"))
                 }
             }
         } else {


### PR DESCRIPTION
main feature: `stripAnnotations = true`
- can be set for everything (inside the `expectPlatform` block) or per transform
- removes annotations from transformed/spared methods

also I apparently didn't make the transformer annotate `@ExpectPlatform` methods with `@Transformed` so they are now

and some extra qol stuff like a `Project.expectPlatform` property