### PR TITLE
add helper to get agent vm args

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '17'
@@ -20,7 +20,7 @@ jobs:
       - name: Publish
         run: ./gradlew publish -Pmvn.user=${{ secrets.MAVEN_USER }} -Pmvn.key=${{ secrets.MAVEN_TOKEN }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Artifacts
           path: ./build/libs/

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ tasks.create("PlatformJar", xyz.wagyourtail.unimined.expect.ExpectPlatformJar) {
 
 ```
 
-if you need the agent on a runner that isn't implementing JavaExecSpec (i.e. the one in unimined 1.2)
-check [the implementation](src/main/kotlin/xyz/wagyourtail/unimined/expect/ExpectPlatformExtension.kt#L69) for how it actually applies the agent to a JavaExec task.
+if you need the agent on a runner that isn't implementing JavaExecSpec (i.e. the one in unimined 1.2), call
+`expectPlatform.getAgentArgs(platformName)` to get the args to pass to the jvm.
 
 ### Environment
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pluginManagement {
 and then add the plugin to your `build.gradle` file:
 ```gradle
 plugins {
-    id 'xyz.wagyourtail.unimined.expect-platform' version '1.0.5'
+    id 'xyz.wagyourtail.unimined.expect-platform' version '1.1.1'
 }
 ```
 

--- a/expect-platform-test/build.gradle.kts
+++ b/expect-platform-test/build.gradle.kts
@@ -122,7 +122,7 @@ tasks.register("runAgentA", JavaExec::class) {
     mainClass = "xyz.wagyourtail.ept.Main"
     group = "ept"
 
-    expectPlatform.insertAgent(this, "a", mapOf(
+    expectPlatform.insertAgent(this,"a", mapOf(
                     "xyz/wagyourtail/unimined/expect/annotation/Environment" to "xyz/wagyourtail/ept/a/Env",
                     "xyz/wagyourtail/unimined/expect/annotation/Environment\$EnvType" to "xyz/wagyourtail/ept/a/Env\$EnvType",
                     "xyz/wagyourtail/unimined/expect/annotation/Environment\$EnvType.COMBINED" to "JOINED",
@@ -134,11 +134,11 @@ tasks.register("runAgentB", JavaExec::class) {
     mainClass = "xyz.wagyourtail.ept.Main"
     group = "ept"
 
-    expectPlatform.insertAgent(this, "b", mapOf(
+    expectPlatform.insertAgent(this,"b", mapOf(
                     "xyz/wagyourtail/unimined/expect/annotation/Environment" to "xyz/wagyourtail/ept/b/OnlyIn",
                     "xyz/wagyourtail/unimined/expect/annotation/Environment.value" to "env",
                     "xyz/wagyourtail/unimined/expect/annotation/Environment\$EnvType" to "xyz/wagyourtail/ept/b/OnlyIn\$Type",
-            ))
+    ))
 }
 
 tasks.register("runAgentC", JavaExec::class) {
@@ -150,7 +150,7 @@ tasks.register("runAgentC", JavaExec::class) {
                     "xyz/wagyourtail/unimined/expect/annotation/Environment" to "xyz/wagyourtail/ept/c/Environment",
                     "xyz/wagyourtail/expect/unimined/annotation/Environment.value" to "type",
                     "xyz/wagyourtail/expect/unimined/annotation/Environment\$EnvType" to "xyz/wagyourtail/ept/c/Environment\$EnvType",
-            ))
+    ))
 }
 
 val jarA by tasks.registering(ExpectPlatformJar::class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
 
-version = 1.1.0
+version = 1.1.1
 
 asmVersion = 9.8

--- a/src/agent/java/xyz/wagyourtail/unimined/expect/ExpectPlatformAgent.java
+++ b/src/agent/java/xyz/wagyourtail/unimined/expect/ExpectPlatformAgent.java
@@ -8,19 +8,27 @@ import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.security.ProtectionDomain;
 
+import static xyz.wagyourtail.unimined.expect.TransformPlatform.PROPERTY_PLATFORM;
+import static xyz.wagyourtail.unimined.expect.TransformPlatform.PROPERTY_REMAP;
+
+
 public class ExpectPlatformAgent {
-    private static final String EXPECT_PLATFORM = "expect.platform";
-    private static final String REMAP = "expect.remap";
-    private static final String platform = System.getProperty(EXPECT_PLATFORM);
-    private static final String remap = System.getProperty(REMAP);
+    private static final String platform = System.getProperty(PROPERTY_PLATFORM);
+    private static final String remap = System.getProperty(PROPERTY_REMAP);
+
+    static {
+        if (platform == null) {
+            throw new IllegalStateException("-D" + PROPERTY_PLATFORM + " not set");
+        }
+
+        if (remap == null) {
+            throw new IllegalStateException("-D" + PROPERTY_REMAP + " not set");
+        }
+    }
 
     private static final TransformPlatform transformPlatform = new TransformPlatform(platform, remap, false);
 
     public static void premain(String args, Instrumentation inst) {
-        if (platform == null) {
-            throw new IllegalStateException("-D" + EXPECT_PLATFORM + " not set");
-        }
-
         if(!inst.isRetransformClassesSupported()) {
             System.out.println("[ExpectPlatformAgent] ur instrumentation is bad lol");
         }

--- a/src/main/kotlin/xyz/wagyourtail/unimined/expect/ExpectPlatformExtension.kt
+++ b/src/main/kotlin/xyz/wagyourtail/unimined/expect/ExpectPlatformExtension.kt
@@ -7,6 +7,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
 import org.gradle.process.JavaExecSpec
 import org.jetbrains.annotations.VisibleForTesting
+import xyz.wagyourtail.unimined.expect.TransformPlatform.*
 import xyz.wagyourtail.unimined.expect.transform.ExpectPlatformParams
 import xyz.wagyourtail.unimined.expect.transform.ExpectPlatformTransform
 import xyz.wagyourtail.unimined.expect.utils.FinalizeOnRead
@@ -18,7 +19,7 @@ val Project.expectPlatform: ExpectPlatformExtension
 abstract class ExpectPlatformExtension(val project: Project) {
 
     @set:VisibleForTesting
-    var version = ExpectPlatformExtension::class.java.`package`.implementationVersion ?: "1.0.0-SNAPSHOT"
+    var version = ExpectPlatformExtension::class.java.`package`.implementationVersion ?: "1.1.0-SNAPSHOT"
 
     val annotationsDep by lazy { "xyz.wagyourtail.unimined.expect-platform:expect-platform-annotations:$version" }
     val agentDep by lazy { "xyz.wagyourtail.unimined.expect-platform:expect-platform-agent:$version:all" }
@@ -75,10 +76,15 @@ abstract class ExpectPlatformExtension(val project: Project) {
 
     @JvmOverloads
     fun insertAgent(spec: JavaExecSpec, platformName: String, remap: Map<String, String> = emptyMap()) {
-        spec.jvmArgs(
+        spec.jvmArgs(getAgentArgs(platformName, remap))
+    }
+
+    @JvmOverloads
+    fun getAgentArgs(platformName: String, remap: Map<String, String> = emptyMap()): List<String> {
+        return listOf(
             "-javaagent:${agentJar.absolutePath}",
-            "-Dexpect.platform=${platformName}",
-            "-Dexpect.remap=${TransformPlatform.mapToString(remap)}"
+            "-D${PROPERTY_PLATFORM}=${platformName}",
+            "-D${PROPERTY_REMAP}=${mapToString(remap)}"
         )
     }
 
@@ -87,8 +93,6 @@ abstract class ExpectPlatformExtension(val project: Project) {
         config.resolve().first { it.extension == "jar" }
     }
 
-    operator fun invoke(action: ExpectPlatformExtension.() -> Unit) {
-        action(this)
-    }
+    operator fun invoke(action: ExpectPlatformExtension.() -> Unit) = action(this)
 
 }

--- a/src/shared/java/xyz/wagyourtail/unimined/expect/TransformPlatform.java
+++ b/src/shared/java/xyz/wagyourtail/unimined/expect/TransformPlatform.java
@@ -17,6 +17,9 @@ import java.util.stream.Stream;
 public class TransformPlatform {
     private static final int EXPECT_PLATFORM_ACCESS = Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC;
 
+    public static final String PROPERTY_PLATFORM = "expect.platform";
+    public static final String PROPERTY_REMAP = "expect.remap";
+
     private static final String EXPECT_PLATFORM_DESC = "Lxyz/wagyourtail/unimined/expect/annotation/ExpectPlatform;";
     private static final String EXPECT_PLATFORM_TRANSFORMED_DESC = "Lxyz/wagyourtail/unimined/expect/annotation/ExpectPlatform$Transformed";
     private static final String PLATFORM_ONLY_DESC = "Lxyz/wagyourtail/unimined/expect/annotation/PlatformOnly;";


### PR DESCRIPTION
most plugins (loom, moddevgradle, forge/neogradle) have the conventional way of configuring runs (usually in a `runs` block) not extend `JavaExecSpec` (like unimined does). so anybody using those plugins would then have to set the agent args themselves, which isn't awesome. 

this pr adds a helper function that just returns the right args, and changes the old `insertAgent` function to call it